### PR TITLE
Fix version file URL field

### DIFF
--- a/GameData/DistantObject/DistantObject.version
+++ b/GameData/DistantObject/DistantObject.version
@@ -1,6 +1,6 @@
 {
   "NAME": "DistantObjectEnhancement",
-  "URL": "https://https://raw.githubusercontent.com/TheDarkBadger/DistantObject/master/GameData/DistantObject/DistantObject.version",
+  "URL": "https://raw.githubusercontent.com/TheDarkBadger/DistantObject/master/GameData/DistantObject/DistantObject.version",
   "DOWNLOAD": "https://github.com/TheDarkBadger/DistantObject/releases",
   "VERSION": {
     "MAJOR": 2,


### PR DESCRIPTION
Only one `https://` is needed.

Tagging @TheDarkBadger to ensure GitHub sends a notification.

This Action can validate version files and catch such problems before release:

https://github.com/DasSkelett/AVC-VersionFileValidator